### PR TITLE
feat(calendar-picker,header): add chip variant to CalendarPicker and …

### DIFF
--- a/example/app/ui-kit/calendar-picker.tsx
+++ b/example/app/ui-kit/calendar-picker.tsx
@@ -30,6 +30,11 @@ export default function CalendarPickerExample() {
     toDate?: string;
   }>({});
 
+  const [selectedDateRange4, setSelectedDateRange4] = useState<{
+    fromDate?: string;
+    toDate?: string;
+  }>({});
+
   return (
     <ResponsiveScroll>
       {headerVisible && (
@@ -112,6 +117,31 @@ export default function CalendarPickerExample() {
         )}
       </Card>
 
+      <Card style={styles.exampleContainer}>
+        <Text variant="h4" style={styles.exampleTitle}>
+          Chip Variant (Filter)
+        </Text>
+        <View style={styles.chipRow}>
+          <CalendarPicker
+            value={selectedDateRange4}
+            onChange={setSelectedDateRange4}
+            variant="chip"
+            chipText="Filter"
+            chipIconName="SlidersHorizontal"
+          />
+        </View>
+        {(selectedDateRange4.fromDate || selectedDateRange4.toDate) && (
+          <Text variant="pm" style={styles.selectedDate}>
+            {selectedDateRange4.fromDate &&
+              !selectedDateRange4.toDate &&
+              `Start: ${new Date(selectedDateRange4.fromDate).toLocaleDateString()}`}
+            {selectedDateRange4.fromDate &&
+              selectedDateRange4.toDate &&
+              `Range: ${new Date(selectedDateRange4.fromDate).toLocaleDateString()} - ${new Date(selectedDateRange4.toDate).toLocaleDateString()}`}
+          </Text>
+        )}
+      </Card>
+
       <View style={styles.spacer} />
     </ResponsiveScroll>
   );
@@ -132,4 +162,5 @@ const styles = StyleSheet.create({
     borderRadius: 4,
   },
   spacer: { height: 40 },
+  chipRow: { flexDirection: 'row', alignItems: 'flex-start' },
 });

--- a/src/components/CalendarPicker.tsx
+++ b/src/components/CalendarPicker.tsx
@@ -19,9 +19,10 @@ import Animated, {
 import InputContainer from './InputContainer';
 import BottomSheet, { type BottomSheetProps } from './BottomSheet';
 import Text from './Text';
-import Icon from './Icon';
+import Icon, { type IconName } from './Icon';
 import Button from './Button';
 import IconButton from './IconButton';
+import Chip from './Chip';
 
 import useTheme from '../hooks/useTheme';
 
@@ -40,6 +41,22 @@ type Props = {
   error?: boolean;
   hint?: string;
   title?: string;
+  /**
+   * Trigger rendering style.
+   * - `'input'` (default): full bordered input with label, icon, chevron and optional hint/error.
+   * - `'chip'`: compact pill (icon + text), ideal for filter toolbars.
+   *   In `'chip'` mode, `label`, `hint` and `error` are ignored.
+   */
+  variant?: 'input' | 'chip';
+  /**
+   * Text shown inside the chip when `variant='chip'`.
+   * Falls back to the formatted selected range, then to `placeholder`.
+   */
+  chipText?: string;
+  /** Icon shown inside the chip when `variant='chip'`. Defaults to `'Calendar'`. */
+  chipIconName?: IconName;
+  /** Size of the chip trigger when `variant='chip'`. Defaults to `'normal'`. */
+  chipSize?: 'normal' | 'small';
 };
 
 // Helper function to safely parse ISO date string to Date object
@@ -69,6 +86,10 @@ const CalendarPicker = ({
   disabled = false,
   error,
   hint,
+  variant = 'input',
+  chipText,
+  chipIconName,
+  chipSize = 'normal',
 }: Props) => {
   const [fromDate, setFromDate] = useState<string | undefined>(
     value?.fromDate ? format(new Date(value.fromDate), 'yyyy-MM-dd') : undefined
@@ -255,39 +276,49 @@ const CalendarPicker = ({
   return (
     <>
       <View style={style}>
-        <InputContainer
-          onPress={handlePress}
-          disabled={disabled}
-          focused={isOpen}
-          error={error}
-          hint={hint}
-          label={label}
-        >
-          <Icon
-            style={styles.icon}
-            name="Calendar"
-            size={18}
-            color={convertHexToRgba(colors.foreground, 0.5)}
+        {variant === 'chip' ? (
+          <Chip
+            text={chipText ?? displayValue ?? placeholder}
+            iconName={chipIconName ?? 'Calendar'}
+            size={chipSize}
+            disabled={disabled}
+            onPress={handlePress}
           />
-          <Text
-            variant="pm"
-            style={[
-              styles.selectText,
-              {
-                color: displayValue
-                  ? getInputTextColor()
-                  : convertHexToRgba(colors.foreground, 0.5),
-                fontFamily: theme.fonts.regular,
-              },
-            ]}
-            numberOfLines={1}
+        ) : (
+          <InputContainer
+            onPress={handlePress}
+            disabled={disabled}
+            focused={isOpen}
+            error={error}
+            hint={hint}
+            label={label}
           >
-            {displayValue ?? placeholder}
-          </Text>
-          <Animated.View style={animatedStyle}>
-            <Icon name="ChevronDown" size={16} color={colors.foreground} />
-          </Animated.View>
-        </InputContainer>
+            <Icon
+              style={styles.icon}
+              name="Calendar"
+              size={18}
+              color={convertHexToRgba(colors.foreground, 0.5)}
+            />
+            <Text
+              variant="pm"
+              style={[
+                styles.selectText,
+                {
+                  color: displayValue
+                    ? getInputTextColor()
+                    : convertHexToRgba(colors.foreground, 0.5),
+                  fontFamily: theme.fonts.regular,
+                },
+              ]}
+              numberOfLines={1}
+            >
+              {displayValue ?? placeholder}
+            </Text>
+            <Animated.View style={animatedStyle}>
+              <Icon name="ChevronDown" size={16} color={colors.foreground} />
+            </Animated.View>
+          </InputContainer>
+        )}
       </View>
       <BottomSheet ref={bottomSheetRef} onBackdropPress={handleClose}>
         <View style={styles.calendarContainer}>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -13,7 +13,7 @@ import { type IconName } from './Icon';
 import useTheme from '../hooks/useTheme';
 
 import meassures from '../theme/meassures';
-import type { ButtonVariant } from './ButtonContainer';
+import type { ButtonSize, ButtonVariant } from './ButtonContainer';
 
 export type HeaderVariant = 'default' | 'secondary';
 
@@ -21,6 +21,7 @@ const DEFAULT_COLLAPSE_THRESHOLD = 80;
 
 type HeaderButtonProps = {
   iconName: IconName;
+  iconSize?: keyof typeof ButtonSize;
   onPress?: () => void;
   disabled?: boolean;
   variant?: keyof typeof ButtonVariant;
@@ -107,7 +108,7 @@ export default function Header({
       <IconButton
         iconName={button.iconName}
         variant={button.variant ?? 'transparent'}
-        size="medium"
+        size={button.iconSize ?? 'medium'}
         onPress={button.onPress}
         disabled={button.disabled}
         rounded={button.rounded}


### PR DESCRIPTION
### DESCRIPTION

Adds a `chip` trigger variant to `CalendarPicker` so it can be used as a compact filter pill (icon + text) in toolbars, without the full input chrome. Also adds `iconSize` to `Header`'s button config so icon button sizes can be customized per button.

### TYPE OF CHANGE

- ◻️ 🐞 Bug fix (non-breaking change which fixes an issue)
- 🔳 ✨ New feature (non-breaking change which adds functionality)
- ◻️ 🧰 Refactor
- ◻️ 🧪 Add unit tests
- ◻️ 📚 Documentation updates
- ◻️ 🚀 Release of new version

### CHANGELOG

- `CalendarPicker`: added `variant?: 'input' | 'chip'` prop — `'input'` is the default and preserves backward compatibility
- `CalendarPicker`: added `chipText`, `chipIconName`, `chipSize` props to configure the chip trigger
- `CalendarPicker`: chip trigger reuses the existing `Chip` component, inheriting its theming and disabled state
- `Header`: added `iconSize` to `HeaderButtonProps` so each header button's icon size can be set independently; falls back to `'medium'` when omitted

### DEMO IOS

- https://github.com/user-attachments/assets/006d7312-a376-4f24-acc3-b8e9e49df9d7

### OBSERVATIONS
- --

### RELATED TICKETS

- --




