### PR TITLE
fix fontweight override + add props to icon for strokewidth

### DIFF
--- a/src/components/Icon.tsx
+++ b/src/components/Icon.tsx
@@ -16,7 +16,13 @@ type Props = Omit<LucideProps, 'style'> & {
   style?: StyleProp<ViewStyle>;
 };
 
-export default function Icon({ name, size = 24, color, style, ...props }: Props) {
+export default function Icon({
+  name,
+  size = 24,
+  color,
+  style,
+  ...props
+}: Props) {
   const { colors } = useTheme();
 
   const IconComponent = icons[name] as LucideIcon;

--- a/src/components/Icon.tsx
+++ b/src/components/Icon.tsx
@@ -1,10 +1,9 @@
 import type { StyleProp, ViewStyle } from 'react-native';
-import type { LucideIcon } from 'lucide-react-native';
+import type { LucideIcon, LucideProps } from 'lucide-react-native';
 import * as icons from 'lucide-react-native';
 
 import useTheme from '../hooks/useTheme';
 
-// Filtrar solo los iconos (excluyendo utilidades como createLucideIcon, etc.)
 type IconsModule = typeof icons;
 type IconKeys = {
   [K in keyof IconsModule]: IconsModule[K] extends LucideIcon ? K : never;
@@ -12,14 +11,12 @@ type IconKeys = {
 
 export type IconName = IconKeys;
 
-type Props = {
-  style?: StyleProp<ViewStyle>;
+type Props = Omit<LucideProps, 'style'> & {
   name: IconName;
-  size?: number;
-  color?: string;
+  style?: StyleProp<ViewStyle>;
 };
 
-export default function Icon({ name, size = 24, color, style }: Props) {
+export default function Icon({ name, size = 24, color, style, ...props }: Props) {
   const { colors } = useTheme();
 
   const IconComponent = icons[name] as LucideIcon;
@@ -29,6 +26,7 @@ export default function Icon({ name, size = 24, color, style }: Props) {
       size={size}
       color={color ?? colors.foreground}
       style={style}
+      {...props}
     />
   );
 }

--- a/src/components/Text.tsx
+++ b/src/components/Text.tsx
@@ -9,7 +9,13 @@ type Props = TextProps & {
   weight?: keyof Theme['fonts'];
 };
 
-export default function Text({ variant, weight, style, children, ...props }: Props) {
+export default function Text({
+  variant,
+  weight,
+  style,
+  children,
+  ...props
+}: Props) {
   const { theme, colors } = useTheme();
 
   const color = useMemo(
@@ -63,7 +69,13 @@ export default function Text({ variant, weight, style, children, ...props }: Pro
   return (
     <RNText
       {...props}
-      style={[textStyle, { color }, styles.text, fontFamily ? { fontFamily } : null, style]}
+      style={[
+        textStyle,
+        { color },
+        styles.text,
+        fontFamily ? { fontFamily } : null,
+        style,
+      ]}
     >
       {children}
     </RNText>

--- a/src/components/Text.tsx
+++ b/src/components/Text.tsx
@@ -1,13 +1,15 @@
 import { useMemo } from 'react';
 import { StyleSheet, Text as RNText, type TextProps } from 'react-native';
 
+import type { Theme } from '../store/themeStore';
 import useTheme from '../hooks/useTheme';
 
 type Props = TextProps & {
   variant: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'pl' | 'pm' | 'ps' | 'caption';
+  weight?: keyof Theme['fonts'];
 };
 
-export default function Text({ variant, style, children, ...props }: Props) {
+export default function Text({ variant, weight, style, children, ...props }: Props) {
   const { theme, colors } = useTheme();
 
   const color = useMemo(
@@ -56,8 +58,13 @@ export default function Text({ variant, style, children, ...props }: Props) {
     }[variant];
   }, [variant, theme.fonts.bold, theme.fonts.medium, theme.fonts.regular]);
 
+  const fontFamily = weight ? theme.fonts[weight] : undefined;
+
   return (
-    <RNText {...props} style={[textStyle, { color }, styles.text, style]}>
+    <RNText
+      {...props}
+      style={[textStyle, { color }, styles.text, fontFamily ? { fontFamily } : null, style]}
+    >
       {children}
     </RNText>
   );

--- a/src/store/themeStore.ts
+++ b/src/store/themeStore.ts
@@ -5,7 +5,13 @@ import { darkColors, lightColors, type ColorPalette } from '../theme/colors';
 
 type Theme = {
   colors: { dark: ColorPalette; light: ColorPalette };
-  fonts: { light: string; regular: string; medium: string; semibold?: string; bold: string };
+  fonts: {
+    light: string;
+    regular: string;
+    medium: string;
+    semibold?: string;
+    bold: string;
+  };
   roundness: number;
   insets: { top: number; left: number; right: number; bottom: number };
 };

--- a/src/store/themeStore.ts
+++ b/src/store/themeStore.ts
@@ -5,7 +5,7 @@ import { darkColors, lightColors, type ColorPalette } from '../theme/colors';
 
 type Theme = {
   colors: { dark: ColorPalette; light: ColorPalette };
-  fonts: { light: string; regular: string; medium: string; bold: string };
+  fonts: { light: string; regular: string; medium: string; semibold?: string; bold: string };
   roundness: number;
   insets: { top: number; left: number; right: number; bottom: number };
 };


### PR DESCRIPTION
### DESCRIPTION

- Added semibold to font family otherwise we had to override fontFamily
- Added ...props for icon to be able to set strokewidth

### TYPE OF CHANGE

- ◻️ 🐞 Bug fix (non-breaking change which fixes an issue)
- ◻️ ✨ New feature (non-breaking change which adds functionality)
- ◻️ 🧰 Refactor
- ◻️ 🧪 Add unit tests
- ◻️ 📚 Documentation updates
- ◻️ 🚀 Release of new version​

(unselected: ◻️, selected: 🔳)

### CHANGELOG

- change 1
- change 2
- change 3​

### DEMO IOS

(Image or video showing changes on the UI side, if not leave --​)

### DEMO ANDROID

(Image or video showing changes on the UI side, if not leave --​)

### DEMO WEB

(Image or video showing changes on the UI side, if not leave --​)

### OBSERVATIONS

(Comments, if not leave --​)

### RELATED TICKETS

- [ticket name](Link URL)
