### PR TITLE
Fix release pipeline npm auth and version handling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: # TEMPORARY: for manually testing this workflow before merge, remove before merging to main
 
 jobs:
   release:
@@ -50,6 +49,6 @@ jobs:
         run: npm install -g npm@latest
 
       - name: Release
-        run: yarn release --dry-run --ci # TEMPORARY: swap back to `yarn release --ci` before merging to main
+        run: yarn release --ci
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch: # TEMPORARY: for manually testing this workflow before merge, remove before merging to main
 
 jobs:
   release:
@@ -36,17 +37,19 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       # npm Trusted Publishing (OIDC) requires npm >= 11.5.1 and Node >= 22.14.0,
-      # newer than the .nvmrc pin used for the build above.
+      # newer than the .nvmrc pin used for the build above. Float to the latest
+      # 22.x patch rather than pinning one, since npm@latest's own engine
+      # requirement creeps forward over time.
       - name: Setup Node.js for npm publish
         uses: actions/setup-node@v4
         with:
-          node-version: '22.14.0'
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Update npm
         run: npm install -g npm@latest
 
       - name: Release
-        run: yarn release --ci
+        run: yarn release --dry-run --ci # TEMPORARY: swap back to `yarn release --ci` before merging to main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,11 @@ jobs:
       - name: Update npm
         run: npm install -g npm@latest
 
+      # Version bumping is expected to already be done in package.json before
+      # this workflow runs (currently done manually; the release-pr skill will
+      # take over computing and committing it). --no-increment tells release-it
+      # to publish whatever version is already there instead of recomputing one.
       - name: Release
-        run: yarn release --ci
+        run: yarn release --ci --no-increment
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -123,7 +123,8 @@
       "tagName": "v${version}"
     },
     "npm": {
-      "publish": true
+      "publish": true,
+      "skipChecks": true
     },
     "github": {
       "release": true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@space-uy/pulsar-ui",
-  "version": "0.11.7",
+  "version": "0.11.6",
   "description": "react native ui kit for spacedev",
   "source": "./src/index.tsx",
   "main": "./lib/module/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@space-uy/pulsar-ui",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "description": "react native ui kit for spacedev",
   "source": "./src/index.tsx",
   "main": "./lib/module/index.js",


### PR DESCRIPTION
### DESCRIPTION

Fixes two blockers in the automated npm release workflow (introduced in #8) that were discovered while running it end-to-end: `release-it`'s `npm whoami` pre-flight check doesn't understand OIDC Trusted Publishing and always reported "not authenticated" even though the real `npm publish` would succeed, and `release-it` was recomputing the version from conventional commits instead of using whatever version is already set in `package.json`. Also floats the publish step's Node version instead of pinning an exact patch, since `npm@latest`'s own engine requirement moves forward over time.

### TYPE OF CHANGE

- 🔳 🐞 Bug fix (non-breaking change which fixes an issue)
- ◻️ ✨ New feature (non-breaking change which adds functionality)
- ◻️ 🧰 Refactor
- ◻️ 🧪 Add unit tests
- ◻️ 📚 Documentation updates
- 🔳 🚀 Release of new version​

(unselected: ◻️, selected: 🔳)

### CHANGELOG

- Added `npm.skipChecks: true` to the `release-it` config so its `npm whoami` pre-flight check (incompatible with OIDC Trusted Publishing) no longer blocks a real publish
- Changed the publish-step `setup-node` version from a pinned `22.14.0` to a floating `'22'`, since `npm@latest` requires a newer Node patch than 22.14.0 provides
- Changed the `Release` step to run `yarn release --ci --no-increment`, so it publishes whatever version is already committed in `package.json` instead of recomputing one from conventional commits (version bumping will move to the upcoming `release-pr` skill)
- Bumped `package.json` to `0.11.7` for this release

### DEMO IOS

--

### DEMO ANDROID

--

### DEMO WEB

--

### OBSERVATIONS

Merging this PR to `main` triggers an automated npm publish of `0.11.7` via the Release workflow.

### RELATED TICKETS

--