### PR TITLE
Fix npm trusted publishing release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ jobs:
   release:
     if: "!contains(github.event.head_commit.message, 'chore: release')"
     runs-on: ubuntu-latest
+    environment: library-release
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,11 +39,16 @@ jobs:
       # newer than the .nvmrc pin used for the build above. Float to the latest
       # 22.x patch rather than pinning one, since npm@latest's own engine
       # requirement creeps forward over time.
+      #
+      # Deliberately omit registry-url: passing it makes setup-node write a
+      # placeholder NODE_AUTH_TOKEN/.npmrc auth token, which makes npm use
+      # classic token auth instead of the OIDC trusted-publishing exchange
+      # (causing a 404 on publish). package.json's publishConfig already
+      # points npm at the right registry with public access.
       - name: Setup Node.js for npm publish
         uses: actions/setup-node@v4
         with:
           node-version: '22'
-          registry-url: 'https://registry.npmjs.org'
 
       - name: Update npm
         run: npm install -g npm@latest


### PR DESCRIPTION
### DESCRIPTION

The release pipeline was failing on `npm publish` with a `404 Not Found` for `@space-uy/pulsar-ui`. The actual cause was that npm's Trusted Publisher configuration for this package expects the release job to run under the `library-release` GitHub Actions environment, but the workflow never declared it, so the OIDC token's environment claim didn't match npm's expectations and the exchange silently failed. npm then fell back to a placeholder auth token written by `actions/setup-node`'s `registry-url` input, and the registry rejected that request with a 404 instead of a clear auth error. This PR wires the job to the correct environment and removes the now-misleading placeholder token config.

### TYPE OF CHANGE

- 🔳 🐞 Bug fix (non-breaking change which fixes an issue)
- ◻️ ✨ New feature (non-breaking change which adds functionality)
- ◻️ 🧰 Refactor
- ◻️ 🧪 Add unit tests
- ◻️ 📚 Documentation updates
- ◻️ 🚀 Release of new version​

(unselected: ◻️, selected: 🔳)

### CHANGELOG

- Scoped the `release` job in `.github/workflows/release.yml` to the `library-release` GitHub Actions environment so its OIDC token matches npm's Trusted Publisher configuration
- Removed `registry-url` from the npm-publish `setup-node` step, since it made `setup-node` write a placeholder auth token that masked OIDC trusted-publishing failures behind a misleading 404 (package.json's `publishConfig` already sets the registry and public access)

### DEMO IOS

--

### DEMO ANDROID

--

### DEMO WEB

--

### OBSERVATIONS

The `library-release` environment already existed in the repo (allows `main`, no required reviewers) but was never referenced by the workflow. Verification requires watching the next push to `main` trigger a release run and confirming `npm publish` succeeds end to end.

### RELATED TICKETS

--