### PR TITLE
ci: fix beta-release EBADENGINE on npm update

### DIFF
--- a/.claude/skills/pull-request/SKILL.md
+++ b/.claude/skills/pull-request/SKILL.md
@@ -49,7 +49,22 @@ Only consider commits that are not merge commits (already filtered in Step 1). D
 
 ## Step 3 — Generate the PR title
 
-Write a concise, descriptive title (under 72 characters) that summarizes the actual work done. Use imperative mood (e.g. "Fix pull-to-refresh behavior on Android", "Add send flow with WDK integration"). Do not include the branch name literally.
+The title MUST follow Conventional Commits format, enforced by CI (`.github/workflows/pr-title.yml`) — a non-compliant title fails the "Validate PR title" check:
+
+```
+<type>[(scope)][!]: <lowercase subject>
+```
+
+- `<type>` is one of: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`
+- `(scope)` is optional
+- `!` after the type/scope marks a breaking change
+- the subject must NOT start with an uppercase letter
+- keep the whole title under 72 characters
+- do not include the branch name literally
+
+Pick `<type>` from what the diff actually is (bug fix → `fix`, new feature → `feat`, CI/workflow change → `ci`, tooling → `chore`, etc.) — match it to the same category used for TYPE OF CHANGE in Step 4.
+
+Examples: `fix: resolve header alignment issue`, `feat: add send flow with WDK integration`, `ci: fix beta-release EBADENGINE on npm update`.
 
 ## Step 4 — Fill in the PR description
 

--- a/.claude/skills/release-pr/SKILL.md
+++ b/.claude/skills/release-pr/SKILL.md
@@ -131,8 +131,10 @@ Read `.github/pull_request_template.md` and use it as the exact base structure, 
 
 ## Step 9 — Create the pull request
 
+The title MUST follow Conventional Commits format, enforced by CI (`.github/workflows/pr-title.yml`) — a non-compliant title fails the "Validate PR title" check. Use `chore(release)` as the type/scope, since this isn't captured by any of the other conventional-commit types:
+
 ```bash
-gh pr create --base $BASE --title "Release v<next-version>" --body "$(cat <<'EOF'
+gh pr create --base $BASE --title "chore(release): v<next-version>" --body "$(cat <<'EOF'
 <filled template content>
 EOF
 )"

--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -65,13 +65,20 @@ jobs:
         run: npm version "${{ steps.version.outputs.version }}" --no-git-tag-version --allow-same-version
 
       # npm Trusted Publishing (OIDC) requires npm >= 11.5.1 and Node >= 22.14.0,
-      # newer than the .nvmrc pin used for the build above.
+      # newer than the .nvmrc pin used for the build above. Float to the latest
+      # 22.x patch rather than pinning one, since npm@latest's own engine
+      # requirement creeps forward over time.
+      #
+      # Deliberately omit registry-url: passing it makes setup-node write a
+      # placeholder NODE_AUTH_TOKEN/.npmrc auth token, which makes npm use
+      # classic token auth instead of the OIDC trusted-publishing exchange
+      # (causing a 404 on publish). package.json's publishConfig already
+      # points npm at the right registry with public access.
       - name: Setup Node.js for npm publish
         if: steps.check.outputs.skip == 'false'
         uses: actions/setup-node@v4
         with:
-          node-version: '22.14.0'
-          registry-url: 'https://registry.npmjs.org'
+          node-version: '22'
 
       - name: Update npm
         if: steps.check.outputs.skip == 'false'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,3 +59,4 @@ Releases are managed via `release-it` with conventional changelog.
 - Do not commit `.env` files or secrets.
 - Do not use `npm` — this project uses Yarn workspaces.
 - Do not bypass pre-commit hooks with `--no-verify`.
+- Never author or co-author commits. Do not add `Co-Authored-By: Claude ...` or similar AI attribution lines to commit messages, PR descriptions, or CHANGELOG.md.


### PR DESCRIPTION
### DESCRIPTION

The beta-release pipeline was failing at the "Update npm" step with an `EBADENGINE` error. The "Setup Node.js for npm publish" step pinned an exact `node-version: '22.14.0'`, but `npm@latest`'s own engine requirement has since moved past that patch (now `^22.22.2 || ^24.15.0 || >=26.0.0`), so the pinned Node version no longer satisfied it. This exact problem was already diagnosed and fixed in `release.yml`, which floats to `node-version: '22'` and omits `registry-url` (needed for OIDC trusted publishing to work correctly); `beta-release.yml` had duplicated the old, already-fixed pattern instead. While validating the fix, the PR title check (`pr-title.yml`) also failed, exposing that the `pull-request` and `release-pr` skills generated titles that don't comply with the repo's enforced Conventional Commits format — both were updated to generate compliant titles going forward. `CLAUDE.md` was also updated to state that commits/PRs must never carry AI co-author attribution.

### TYPE OF CHANGE

- 🔳 🐞 Bug fix (non-breaking change which fixes an issue)
- ◻️ ✨ New feature (non-breaking change which adds functionality)
- 🔳 🧰 Refactor
- ◻️ 🧪 Add unit tests
- 🔳 📚 Documentation updates
- ◻️ 🚀 Release of new version​

(unselected: ◻️, selected: 🔳)

### CHANGELOG

- Changed `node-version` in `beta-release.yml`'s "Setup Node.js for npm publish" step from a pinned `'22.14.0'` to a floating `'22'`, so it always resolves to a patch that satisfies `npm@latest`'s engine requirement
- Removed `registry-url` from that same step, matching `release.yml`, since setting it causes `actions/setup-node` to write a placeholder npm auth token that breaks the OIDC trusted-publishing exchange
- Updated the `pull-request` skill to generate PR titles in Conventional Commits format (`type(scope)!: lowercase subject`), matching the format enforced by `pr-title.yml`
- Updated the `release-pr` skill's PR title from `"Release v<next-version>"` to `"chore(release): v<next-version>"`, since the former also didn't comply with the enforced format
- Added a rule to `CLAUDE.md` prohibiting AI authorship/co-authorship attribution in commits, PR descriptions, and `CHANGELOG.md`

### DEMO IOS

--

### DEMO ANDROID

--

### DEMO WEB

--

### OBSERVATIONS

Verified by pushing this branch and manually triggering `beta-release.yml` via `workflow_dispatch` with `dry_run: true` (run [29940102518](https://github.com/SpaceUY/pulsar-ui/actions/runs/29940102518)): all steps through "Update npm" passed, confirming the `EBADENGINE` failure is resolved. "Publish beta" was skipped only because of `dry_run`. The PR title was renamed to `ci: fix beta-release EBADENGINE on npm update` to satisfy the "Validate PR title" check, which now passes.

### RELATED TICKETS

--